### PR TITLE
Update redvid.py

### DIFF
--- a/redvid/redvid.py
+++ b/redvid/redvid.py
@@ -151,7 +151,7 @@ class Downloader(Requester):
                 )
 
         # Moving video file without using shutil
-        os.rename(self.temp + self.__unique_id + 'av.mp4', self.file_name)
+        os.rename(self.temp + self.__unique_id + 'video.mp4', self.file_name)
 
         # Clean Temp folder
         Clean(self.temp)


### PR DESCRIPTION
Bug on Windows 11 where file path contained "av.mp4" instead of "video.mp4" which was causing the program to be unable to find the proper file, and the entire python package was erroring out. This bug should be able to be reproduced simply by running the program, but I was also using a custom filename, and custom path. This pull request should fix this bug, as I edited the file on my local pc and ran the package, and everything was successful.