### PR TITLE
changing BaseException to Exception so they follow Pep8 and are catchable without catching BaseExceptions

### DIFF
--- a/redvid/redvid.py
+++ b/redvid/redvid.py
@@ -84,7 +84,7 @@ class Downloader(Requester):
         if self.page.status_code == 200:
             return True
         
-        raise BaseException('Incorrect URL format')
+        raise Exception('Incorrect URL format')
 
     def scrape(self):
         """
@@ -94,7 +94,7 @@ class Downloader(Requester):
 
         if not self.UNQ:
             Clean(self.temp)
-            raise BaseException('No video in this post')
+            raise Exception('No video in this post')
         
         self.r_url = 'https://v.redd.it/' + self.UNQ + '/'
 
@@ -110,7 +110,7 @@ class Downloader(Requester):
         VQS, AQS = mpdParse(mpd.text, custom_video_qualities=max_min_qualities)
 
         if [VQS, AQS] == [0, 0]:
-            raise BaseException('Qualities not found!')
+            raise Exception('Qualities not found!')
 
         self.videos = VQS
 


### PR DESCRIPTION
This is my first public PR so bear with me if anything is wrong.

You are currently using BaseExceptions where Exceptions should be. Base Exceptions are for things like keyboard interrupts or quitting the program. 

The normal `except Exception as e:` wont catch BaseExceptions which is how I found this as I was smashing my head into the desk wondering why your exceptions were stalling my asynchronous program and not being caught/handled.

A good explanation can be found here if you want more info: https://stackoverflow.com/questions/27995057/why-is-it-recommended-to-derive-from-exception-instead-of-baseexception-class-in
or in the PEP guide here: https://peps.python.org/pep-0008/#programming-recommendations